### PR TITLE
Fix bug where "Downloading images" toast is stuck on screen if no images need to be downloaded

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ minecraft_version=1.21.4
 yarn_mappings=build.1
 loader_version=0.16.9
 fabric_version=0.110.5
-roundalib_version=2.3.0
+roundalib_version=2.3.2
 mod_menu_version=13.0.0-beta.1
 dev_login_version=3.5
 

--- a/src/main/java/me/roundaround/custompaintings/client/toast/DownloadProgressToast.java
+++ b/src/main/java/me/roundaround/custompaintings/client/toast/DownloadProgressToast.java
@@ -105,6 +105,8 @@ public class DownloadProgressToast implements Toast {
     if (bytesExpected == 0 && progress < 1f) {
       this.progress = 1f;
       this.finishTime = time;
+
+      this.description = this.getDescription();
     }
   }
 

--- a/src/main/java/me/roundaround/custompaintings/client/toast/DownloadProgressToast.java
+++ b/src/main/java/me/roundaround/custompaintings/client/toast/DownloadProgressToast.java
@@ -101,6 +101,11 @@ public class DownloadProgressToast implements Toast {
 
     this.lastProgress = lerpedProgress;
     this.lastTime = time;
+
+    if (bytesExpected == 0 && progress < 1f) {
+      this.progress = 1f;
+      this.finishTime = time;
+    }
   }
 
   public void setReceived(int images, int bytes) {


### PR DESCRIPTION
Hello! I noticed this bug playing on a server with my friends. It looks like the progress is only being updated when a new image is successfully sent to a player. However, if there are no images to be sent, the download progress and finish time are never updated, so they both get stuck at 0. This results in the DownloadProgressToast being stuck in the top right of the screen, forever, as well as the percentage displayed being stuck at 0%.

I added a check in drawProgressBar for if there are no bytes expected, and if so, to automatically set the progress to 1, finish time to the current time, and update the percentage displayed. I put it in drawProgressBar because I had access to the current time there, which may be a little inelegant. But hopefully this preserves all the other intended behavior of the toast, e.g. the pretty interpolated progress bar. It looked like it did when I tested it.

Also I had to update Roundalib to 2.3.2 otherwise the build would fail; not sure why. But that's why the first commit is there.

Thanks for making this mod! My friend is an artist and we've been using the mod to upload his artwork to our server and make paintings with it. Super cool :)